### PR TITLE
[fix]: When not set `attribute` of `json` type, then throw an error

### DIFF
--- a/packages/core/helper-plugin/src/components/GenericInput.tsx
+++ b/packages/core/helper-plugin/src/components/GenericInput.tsx
@@ -227,7 +227,7 @@ const GenericInput = ({
           onChange={(json) => {
             // Default to null when the field is not required and there is no input value
             const value =
-              'required' in attribute && !attribute?.required && !json.length ? null : json;
+              attribute && 'required' in attribute && !attribute?.required && !json.length ? null : json;
             onChange({ target: { name, value } }, false);
           }}
           minHeight={pxToRem(252)}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fix the `json` type `Input Component` when not set the `attribute` props, Trigger `onChange` event throw error `TypeError: Cannopt use 'in' operator to search for 'required' in undefined`

### Why is it needed?

The `json` type `Input Component` when not set the `attribute` props, Trigger `onChange` event throw error `TypeError: Cannopt use 'in' operator to search for 'required' in undefined`

### How to test it?

Use `CTB` `FormsAPI` to extend field, add an `json` type field, not set `attribute` property. And type in this field, then throw error.

### Related issue(s)/PR(s)

Nop.
